### PR TITLE
Check agent visibility and api keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,91 +1,14 @@
-# Dependencies
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# Production builds
-dist/
-build/
-
-# Environment variables
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# IDE files
-.vscode/
-.idea/
-*.swp
-*.swo
-
-# OS generated files
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
+# Node
+node_modules
+.next
+out
+dist
 
 # Logs
-logs
 *.log
 
-# Database
-*.sqlite
-*.db
+# OS
+.DS_Store
 
-# Temporary files
-.tmp/
-temp/
-
-# Replit specific
-.replit
-.upm
-replit.nix
-
-# Cache directories
-.cache/
-.parcel-cache/
-
-# Coverage directory used by tools like istanbul
-coverage/
-
-# Dependency directories
-jspm_packages/
-
-# Optional npm cache directory
-.npm
-
-# Optional REPL history
-.node_repl_history
-
-# Output of 'npm pack'
-*.tgz
-
-# Yarn Integrity file
-.yarn-integrity
-
-# dotenv environment variables file
-.env.test
-
-# Next.js
-.next
-
-# Nuxt.js
-.nuxt
-
-# Gatsby
-.cache/
-public
-
-# Storybook
-.out
-.storybook-out
-
-# Temporary folders
-tmp/
-temp/
+# Env
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.6.1",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4358,6 +4359,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.6.1",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,11 @@
 import express, { type Request, Response, NextFunction } from "express";
+import dotenv from "dotenv";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { ExtensionWebSocketServer } from "./websocket-server";
+
+// Load env variables early
+dotenv.config();
 
 const app = express();
 app.use(express.json());

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -385,12 +385,12 @@ export class MemStorage implements IStorage {
     const id = randomUUID();
     const agent: Agent = { 
       ...insertAgent,
-      rating: 45,
-      reviewCount: 0,
-      isBundle: true,
+      rating: (insertAgent as any).rating ?? 45,
+      reviewCount: (insertAgent as any).reviewCount ?? 0,
+      isBundle: (insertAgent as any).isBundle ?? true,
       subAgentIds: (insertAgent.subAgentIds ? [...(insertAgent.subAgentIds as any[])] : []) as any,
       tasks: (insertAgent.tasks ? [...(insertAgent.tasks as any[])] : []) as any,
-      featured: false,
+      featured: (insertAgent as any).featured ?? false,
       id 
     };
     this.agents.set(id, agent);


### PR DESCRIPTION
Integrate OpenRouter DeepSeek API keys and enable dynamic agent visibility with connectivity tests on the dashboard.

Agents were not visible because the `createAgent` function hardcoded `featured: false`. This PR fixes that, adds `dotenv` support to load OpenRouter keys, sets DeepSeek as the default LLM, and introduces dashboard features to display agent status and test connectivity, including a fallback for OpenRouter 402 (credit limit) errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-98a89574-021b-4602-9d77-c2326498e89e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98a89574-021b-4602-9d77-c2326498e89e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

